### PR TITLE
schema.graphqlにスキーマを追加して生成しようとしたらエラー

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,7 @@ type User {
 
 type Query {
   todos: [Todo!]!
+  todo(id: ID!): Todo!
 }
 
 input NewTodo {


### PR DESCRIPTION
```
% go run github.com/99designs/gqlgen                                            (git)-[error]
validation failed: packages.Load: /Users/wadanatsuki/repository/test_go_graphql/interfaces/resolvers/root_resolver.go:25:60: cannot use &(queryResolver literal) (value of type *queryResolver) as graphql.QueryResolver value in return statement: missing method Todo
exit status 1
```